### PR TITLE
[codex] Add help menu and inline guidance

### DIFF
--- a/Sources/SwiftMux/App/AppCommands.swift
+++ b/Sources/SwiftMux/App/AppCommands.swift
@@ -4,15 +4,28 @@ import SwiftUI
 extension Notification.Name {
     static let swiftMuxOpenCommandPalette = Notification.Name("swiftmux.open-command-palette")
     static let swiftMuxSelectSidebarSessionIndex = Notification.Name("swiftmux.select-sidebar-session-index")
+    static let swiftMuxShowHelp = Notification.Name("swiftmux.show-help")
+    static let swiftMuxFocusSidebarSearch = Notification.Name("swiftmux.focus-sidebar-search")
+    static let swiftMuxRefreshSessions = Notification.Name("swiftmux.refresh-sessions")
 }
 
 struct AppCommands: Commands {
     var body: some Commands {
         CommandMenu("Navigate") {
+            Button("Search Sessions") {
+                NotificationCenter.default.post(name: .swiftMuxFocusSidebarSearch, object: nil)
+            }
+            .keyboardShortcut("f", modifiers: [.command])
+
             Button("Command Palette") {
                 NotificationCenter.default.post(name: .swiftMuxOpenCommandPalette, object: nil)
             }
             .keyboardShortcut("k", modifiers: [.command])
+
+            Button("Refresh Sessions") {
+                NotificationCenter.default.post(name: .swiftMuxRefreshSessions, object: nil)
+            }
+            .keyboardShortcut("r", modifiers: [.command])
 
             Divider()
 
@@ -27,5 +40,28 @@ struct AppCommands: Commands {
                 .keyboardShortcut(KeyEquivalent(Character(String(index))), modifiers: [.command])
             }
         }
+
+        CommandGroup(after: .help) {
+            Button("SwiftMux Help") {
+                postHelp(topic: .overview)
+            }
+            .keyboardShortcut("/", modifiers: [.command, .shift])
+
+            Button("Keyboard Shortcuts") {
+                postHelp(topic: .shortcuts)
+            }
+
+            Button("Session Actions") {
+                postHelp(topic: .sessions)
+            }
+        }
+    }
+
+    private func postHelp(topic: SwiftMuxHelpTopic) {
+        NotificationCenter.default.post(
+            name: .swiftMuxShowHelp,
+            object: nil,
+            userInfo: ["topic": topic.rawValue]
+        )
     }
 }

--- a/Sources/SwiftMux/Views/HelpSupport.swift
+++ b/Sources/SwiftMux/Views/HelpSupport.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+
+enum SwiftMuxHelpTopic: String, CaseIterable, Identifiable {
+    case overview
+    case shortcuts
+    case sessions
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .overview:
+            return "Overview"
+        case .shortcuts:
+            return "Shortcuts"
+        case .sessions:
+            return "Session Actions"
+        }
+    }
+
+    var headline: String {
+        switch self {
+        case .overview:
+            return "SwiftMux is built to move between tmux sessions without leaving the keyboard."
+        case .shortcuts:
+            return "The app is fastest when you treat the sidebar and command palette as your navigation layer."
+        case .sessions:
+            return "Each session row exposes lightweight inspection and recovery actions before you attach."
+        }
+    }
+}
+
+struct SwiftMuxHelpSheet: View {
+    @Binding var selectedTopic: SwiftMuxHelpTopic
+    let onOpenPalette: () -> Void
+    let onFocusSidebarSearch: () -> Void
+    let onRefresh: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("SwiftMux Help")
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
+
+                    Text(selectedTopic.headline)
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(AppTheme.mutedText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 20)
+
+                Button("Done") {
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+
+            Picker("Topic", selection: $selectedTopic) {
+                ForEach(SwiftMuxHelpTopic.allCases) { topic in
+                    Text(topic.title).tag(topic)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    switch selectedTopic {
+                    case .overview:
+                        HelpCard(
+                            title: "Daily flow",
+                            text: "Use the sidebar for scanning and lightweight filtering, then drop into the terminal pane once you attach to a session."
+                        )
+                        HelpCard(
+                            title: "Command palette",
+                            text: "Press Cmd-K to fuzzy-search by session name, repo, branch, process, or description and switch immediately."
+                        )
+                        HelpCard(
+                            title: "Recovery",
+                            text: "If the tmux client detaches or switching fails, the detail pane surfaces the error and offers a Reconnect action."
+                        )
+                    case .shortcuts:
+                        ShortcutCard(
+                            title: "Navigation",
+                            shortcuts: [
+                                ("Cmd-F", "Focus the sidebar filter"),
+                                ("Cmd-K", "Open the command palette"),
+                                ("Cmd-1...9", "Jump to one of the first visible sessions")
+                            ]
+                        )
+                        ShortcutCard(
+                            title: "Lists and sheets",
+                            shortcuts: [
+                                ("Up / Down", "Move through sidebar rows or command palette results"),
+                                ("Enter", "Switch to the highlighted command palette result"),
+                                ("Esc", "Dismiss the command palette")
+                            ]
+                        )
+                        ShortcutCard(
+                            title: "Maintenance",
+                            shortcuts: [
+                                ("Cmd-R", "Refresh sessions from tmux-pilot"),
+                                ("Scroll", "Send tmux mouse-wheel events inside the terminal pane")
+                            ]
+                        )
+                    case .sessions:
+                        HelpCard(
+                            title: "Sidebar row actions",
+                            text: "Right-click a session to peek at recent output, copy its name, or kill it without switching."
+                        )
+                        HelpCard(
+                            title: "Status chips",
+                            text: "Session badges show whether work is active, idle, done, or waiting on a human response."
+                        )
+                        HelpCard(
+                            title: "Metadata",
+                            text: "Repo, branch, process, and working directory stay visible in the detail pane so you can confirm context before typing."
+                        )
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+
+            Divider()
+                .overlay(AppTheme.border)
+
+            HStack(spacing: 10) {
+                HelpActionButton(title: "Focus Search", systemImage: "magnifyingglass") {
+                    dismiss()
+                    onFocusSidebarSearch()
+                }
+
+                HelpActionButton(title: "Open Palette", systemImage: "command") {
+                    dismiss()
+                    onOpenPalette()
+                }
+
+                HelpActionButton(title: "Refresh", systemImage: "arrow.clockwise") {
+                    dismiss()
+                    onRefresh()
+                }
+            }
+        }
+        .padding(24)
+        .frame(width: 720, height: 560, alignment: .topLeading)
+        .background(AppTheme.panelBackground)
+    }
+}
+
+struct SidebarGuidanceCard: View {
+    let onOpenHelp: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "questionmark.circle")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(AppTheme.activeAccent)
+                .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Cmd-F filters the sidebar. Cmd-K jumps anywhere. Right-click a row for Peek, Copy Name, or Kill.")
+                    .font(.system(size: 11, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.92))
+
+                Button("Open Help") {
+                    onOpenHelp()
+                }
+                .buttonStyle(.link)
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(AppTheme.elevatedBackground.opacity(0.9))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+struct SessionGuidanceCard: View {
+    let statusMessage: String
+    let lastRefresh: Date?
+    let onOpenHelp: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 8) {
+                Image(systemName: "bolt.horizontal.circle")
+                    .foregroundColor(AppTheme.activeAccent)
+
+                Text(statusMessage)
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+
+                Spacer(minLength: 8)
+
+                if let lastRefresh {
+                    Text("Updated \(lastRefresh, format: .dateTime.hour().minute())")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundColor(AppTheme.mutedText)
+                }
+            }
+
+            HStack(spacing: 12) {
+                Text("Scroll in the terminal for tmux copy-mode.")
+                Text("Cmd-K switches sessions.")
+                Button("Help") {
+                    onOpenHelp()
+                }
+                .buttonStyle(.link)
+            }
+            .font(.system(size: 10, weight: .medium, design: .rounded))
+            .foregroundColor(AppTheme.mutedText)
+        }
+        .padding(12)
+        .background(AppTheme.panelBackground)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(AppTheme.border, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+private struct HelpCard: View {
+    let title: String
+    let text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
+
+            Text(text)
+                .font(.system(size: 12, weight: .regular, design: .rounded))
+                .foregroundColor(AppTheme.mutedText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(AppTheme.windowBackground)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(AppTheme.border, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct ShortcutCard: View {
+    let title: String
+    let shortcuts: [(String, String)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
+
+            ForEach(Array(shortcuts.enumerated()), id: \.offset) { _, shortcut in
+                HStack(alignment: .top, spacing: 12) {
+                    Text(shortcut.0)
+                        .font(.system(size: 11, weight: .bold, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.96))
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(AppTheme.elevatedBackground)
+                        .clipShape(Capsule())
+
+                    Text(shortcut.1)
+                        .font(.system(size: 12, weight: .regular, design: .rounded))
+                        .foregroundColor(AppTheme.mutedText)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(AppTheme.windowBackground)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(AppTheme.border, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+private struct HelpActionButton: View {
+    let title: String
+    let systemImage: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(AppTheme.elevatedBackground)
+    }
+}

--- a/Sources/SwiftMux/Views/RootView.swift
+++ b/Sources/SwiftMux/Views/RootView.swift
@@ -5,14 +5,21 @@ struct RootView: View {
     @StateObject private var sessionManager = SessionManager()
     @StateObject private var terminalState = TmuxTerminalState()
     @State private var commandPalettePresented = false
+    @State private var helpPresented = false
+    @State private var helpTopic: SwiftMuxHelpTopic = .overview
 
     var body: some View {
         NavigationView {
-            SessionSidebarView(sessionManager: sessionManager)
+            SessionSidebarView(
+                sessionManager: sessionManager,
+                onOpenHelp: { presentHelp() }
+            )
             SessionDetailView(
                 session: sessionManager.selectedSession,
                 lastRefresh: sessionManager.lastRefresh,
-                terminalState: terminalState
+                terminalState: terminalState,
+                onOpenHelp: { presentHelp(topic: .sessions) },
+                onRefresh: refreshSessions
             )
         }
         .background(AppTheme.windowBackground)
@@ -25,14 +32,14 @@ struct RootView: View {
                 } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
+                .help("Reload tmux sessions from tmux-pilot")
 
                 Button {
                     commandPalettePresented = true
                 } label: {
                     Label("Command Palette", systemImage: "magnifyingglass")
                 }
-
-
+                .help("Jump to a tmux session with fuzzy search")
             }
         }
         .sheet(isPresented: $commandPalettePresented) {
@@ -40,11 +47,42 @@ struct RootView: View {
                 sessionManager.selectedSessionID = session.id
             }
         }
+        .sheet(isPresented: $helpPresented) {
+            SwiftMuxHelpSheet(
+                selectedTopic: $helpTopic,
+                onOpenPalette: { commandPalettePresented = true },
+                onFocusSidebarSearch: focusSidebarSearch,
+                onRefresh: refreshSessions
+            )
+        }
         .onReceive(NotificationCenter.default.publisher(for: .swiftMuxOpenCommandPalette)) { _ in
             commandPalettePresented = true
         }
+        .onReceive(NotificationCenter.default.publisher(for: .swiftMuxShowHelp)) { notification in
+            let topic = (notification.userInfo?["topic"] as? String)
+                .flatMap(SwiftMuxHelpTopic.init(rawValue:))
+            presentHelp(topic: topic ?? .overview)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .swiftMuxRefreshSessions)) { _ in
+            refreshSessions()
+        }
         .task {
             sessionManager.startPolling()
+        }
+    }
+
+    private func presentHelp(topic: SwiftMuxHelpTopic = .overview) {
+        helpTopic = topic
+        helpPresented = true
+    }
+
+    private func focusSidebarSearch() {
+        NotificationCenter.default.post(name: .swiftMuxFocusSidebarSearch, object: nil)
+    }
+
+    private func refreshSessions() {
+        Task {
+            await sessionManager.refresh()
         }
     }
 }
@@ -75,6 +113,7 @@ private struct SessionSidebarView: View {
     }
 
     @ObservedObject var sessionManager: SessionManager
+    let onOpenHelp: () -> Void
     @State private var tab: SidebarTab = .recent
     @State private var searchText = ""
     @FocusState private var focusTarget: FocusTarget?
@@ -136,6 +175,7 @@ private struct SessionSidebarView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(AppTheme.panelBackground)
+            .help("Filter by session name, repo, branch, process, or description")
 
             // Tab picker
             Picker("View", selection: $tab) {
@@ -146,6 +186,10 @@ private struct SessionSidebarView: View {
             .pickerStyle(.segmented)
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
+
+            SidebarGuidanceCard(onOpenHelp: onOpenHelp)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
 
             List(selection: $sessionManager.selectedSessionID) {
                 if let pollError = sessionManager.pollError {
@@ -212,11 +256,15 @@ private struct SessionSidebarView: View {
             }
             .listStyle(.sidebar)
             .background(AppTheme.sidebarBackground)
+            .help("Select a session to attach. Right-click rows for Peek, Copy Name, or Kill.")
         }
         .background(AppTheme.sidebarBackground)
         .navigationTitle("SwiftMux")
         .onAppear {
             focusTarget = .list
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .swiftMuxFocusSidebarSearch)) { _ in
+            focusTarget = .search
         }
         .onReceive(NotificationCenter.default.publisher(for: .swiftMuxSelectSidebarSessionIndex)) { notification in
             guard let index = notification.userInfo?["index"] as? Int else {
@@ -439,6 +487,8 @@ private struct SessionDetailView: View {
     let session: SessionInfo?
     let lastRefresh: Date?
     @ObservedObject var terminalState: TmuxTerminalState
+    let onOpenHelp: () -> Void
+    let onRefresh: () -> Void
 
     var body: some View {
         ZStack {
@@ -467,6 +517,12 @@ private struct SessionDetailView: View {
                             .lineLimit(1)
                     }
 
+                    SessionGuidanceCard(
+                        statusMessage: terminalState.statusMessage,
+                        lastRefresh: lastRefresh,
+                        onOpenHelp: onOpenHelp
+                    )
+
                     if let error = terminalState.lastError {
                         HStack {
                             Text(error)
@@ -485,6 +541,7 @@ private struct SessionDetailView: View {
                         .id(terminalState.resetToken)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .background(AppTheme.panelBackground)
+                        .help("Attached tmux client. Scroll wheel input is forwarded to tmux mouse mode.")
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                         .overlay(
                             RoundedRectangle(cornerRadius: 8)
@@ -493,8 +550,41 @@ private struct SessionDetailView: View {
                 }
                 .padding(12)
             } else {
-                Text("No tmux sessions found.")
-                    .foregroundColor(AppTheme.mutedText)
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("No tmux sessions found")
+                        .font(.system(size: 22, weight: .bold, design: .rounded))
+
+                    Text("SwiftMux reads sessions from `tp ls --json`. Start tmux work, then refresh to populate the sidebar.")
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(AppTheme.mutedText)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("1. Make sure tmux is running.")
+                        Text("2. Install `tmux-pilot` so `tp` is available.")
+                        Text("3. Use Cmd-R to refresh once sessions exist.")
+                    }
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.92))
+
+                    HStack(spacing: 10) {
+                        Button("Refresh") {
+                            onRefresh()
+                        }
+
+                        Button("Open Help") {
+                            onOpenHelp()
+                        }
+                    }
+                }
+                .padding(24)
+                .frame(maxWidth: 520, alignment: .leading)
+                .background(AppTheme.panelBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(AppTheme.border, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 14))
             }
         }
     }


### PR DESCRIPTION
## Summary
Adds the first practical help/docs pass for SwiftMux.

- adds app-level Help menu entries for SwiftMux help, keyboard shortcuts, and session actions
- adds an in-app help sheet with practical workflow and shortcut guidance
- adds inline guidance in the sidebar, detail pane, and empty state so the core tmux workflow is discoverable in-app

## Why
SwiftMux already had strong navigation primitives, but very little visible guidance around how to use them. This change makes keyboard flows, recovery actions, and session affordances easier to discover from the UI itself.

## Validation
- `swift build`