### PR TITLE
[codex] Fix terminal scrollback session switching

### DIFF
--- a/Sources/SwiftMux/Services/TmuxTerminalState.swift
+++ b/Sources/SwiftMux/Services/TmuxTerminalState.swift
@@ -9,13 +9,15 @@ final class TmuxTerminalState: ObservableObject {
     @Published private(set) var statusMessage = "Select a tmux session"
     @Published private(set) var lastError: String?
 
-    func prepareLaunch(for sessionName: String) -> URL {
+    func prepareLaunch(for sessionName: String) {
         connectedSessionName = nil
         currentDirectory = nil
         terminalTitle = "SwiftMux"
         statusMessage = "Attaching \(sessionName)"
         lastError = nil
+    }
 
+    static func ttyHandshakeURL(for sessionName: String) -> URL {
         let safeName = sessionName.replacingOccurrences(of: "/", with: "-")
         return FileManager.default.temporaryDirectory
             .appendingPathComponent("swiftmux-\(safeName)-\(UUID().uuidString)")
@@ -25,6 +27,13 @@ final class TmuxTerminalState: ObservableObject {
     func markConnected(sessionName: String, tty: String) {
         connectedSessionName = sessionName
         statusMessage = "Attached to \(sessionName) on \(tty)"
+        lastError = nil
+    }
+
+    func prepareSwitch(to sessionName: String) {
+        currentDirectory = nil
+        terminalTitle = "SwiftMux"
+        statusMessage = "Switching to \(sessionName)"
         lastError = nil
     }
 

--- a/Sources/SwiftMux/Views/TmuxTerminalView.swift
+++ b/Sources/SwiftMux/Views/TmuxTerminalView.swift
@@ -37,6 +37,7 @@ struct TmuxTerminalView: NSViewRepresentable {
         private weak var terminalView: LocalProcessTerminalView?
         private let terminalState: TmuxTerminalState
         private var launchedSessionName: String?
+        private var pendingSwitchSessionName: String?
         private var ttyHandshakeURL: URL?
         private var activeTTY: String?
         private var ttyPollingTask: Task<Void, Never>?
@@ -58,7 +59,9 @@ struct TmuxTerminalView: NSViewRepresentable {
         func teardown() {
             ttyPollingTask?.cancel()
             switchTask?.cancel()
+            pendingSwitchSessionName = nil
             resetPreciseScrollState()
+
             if let scrollMonitor {
                 NSEvent.removeMonitor(scrollMonitor)
                 self.scrollMonitor = nil
@@ -82,16 +85,33 @@ struct TmuxTerminalView: NSViewRepresentable {
             }
 
             guard launchedSessionName != session.name else {
+                pendingSwitchSessionName = nil
+                return
+            }
+
+            guard pendingSwitchSessionName != session.name else {
                 return
             }
 
             guard let activeTTY else {
-                terminalState.requestReconnect(for: session.name)
+                deferTerminalStateUpdate { state in
+                    state.requestReconnect(for: session.name)
+                }
                 return
             }
 
             switchTask?.cancel()
             let targetSessionName = session.name
+            pendingSwitchSessionName = targetSessionName
+            resetPreciseScrollState()
+            deferTerminalStateUpdate { state in
+                state.prepareSwitch(to: targetSessionName)
+            }
+            deferSwitch(to: targetSessionName, activeTTY: activeTTY, in: terminalView)
+        }
+
+        private func startSwitch(to targetSessionName: String, activeTTY: String) {
+            switchTask?.cancel()
             switchTask = Task.detached(priority: .userInitiated) { [weak self] in
                 do {
                     _ = try CommandRunner.runExpectingSuccess(
@@ -109,13 +129,17 @@ struct TmuxTerminalView: NSViewRepresentable {
         private func launch(sessionName: String, in terminalView: LocalProcessTerminalView) {
             ttyPollingTask?.cancel()
             switchTask?.cancel()
+            pendingSwitchSessionName = nil
 
-            let ttyHandshakeURL = terminalState.prepareLaunch(for: sessionName)
+            let ttyHandshakeURL = TmuxTerminalState.ttyHandshakeURL(for: sessionName)
             try? FileManager.default.removeItem(at: ttyHandshakeURL)
 
             self.ttyHandshakeURL = ttyHandshakeURL
             self.activeTTY = nil
             self.launchedSessionName = sessionName
+            deferTerminalStateUpdate { state in
+                state.prepareLaunch(for: sessionName)
+            }
 
             // Respect the session's existing tmux mouse configuration so native text selection keeps working.
             let shellCommand = "tty > \(shellQuoted(ttyHandshakeURL.path)); exec tmux attach-session -t \(shellQuoted(sessionName))"
@@ -152,16 +176,30 @@ struct TmuxTerminalView: NSViewRepresentable {
         }
 
         private func completeSwitch(to sessionName: String) {
+            guard lastRequestedSessionName == sessionName else {
+                return
+            }
+
             launchedSessionName = sessionName
+            pendingSwitchSessionName = nil
             terminalState.markSwitched(to: sessionName)
         }
 
         private func handleSwitchFailure(_ error: Error, sessionName: String) {
+            guard lastRequestedSessionName == sessionName else {
+                return
+            }
+
+            pendingSwitchSessionName = nil
             terminalState.reportError(error.localizedDescription)
             terminalState.requestReconnect(for: sessionName)
         }
 
         private func completeHandshake(sessionName: String, tty: String) {
+            guard lastRequestedSessionName == sessionName else {
+                return
+            }
+
             activeTTY = tty
             terminalState.markConnected(sessionName: sessionName, tty: tty)
         }
@@ -201,6 +239,34 @@ struct TmuxTerminalView: NSViewRepresentable {
             "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
         }
 
+        private func deferTerminalStateUpdate(_ update: @escaping @MainActor (TmuxTerminalState) -> Void) {
+            DispatchQueue.main.async { [terminalState] in
+                Task { @MainActor in
+                    update(terminalState)
+                }
+            }
+        }
+
+        private func deferSwitch(
+            to targetSessionName: String,
+            activeTTY: String,
+            in terminalView: LocalProcessTerminalView
+        ) {
+            DispatchQueue.main.async { [weak self, weak terminalView] in
+                Task { @MainActor [weak self, weak terminalView] in
+                    guard let self,
+                          let terminalView,
+                          self.lastRequestedSessionName == targetSessionName,
+                          self.pendingSwitchSessionName == targetSessionName else {
+                        return
+                    }
+
+                    self.prepareTerminalForSessionTransition(in: terminalView)
+                    self.startSwitch(to: targetSessionName, activeTTY: activeTTY)
+                }
+            }
+        }
+
         private func installScrollMonitorIfNeeded() {
             guard scrollMonitor == nil else {
                 return
@@ -215,26 +281,36 @@ struct TmuxTerminalView: NSViewRepresentable {
             }
         }
 
+        private func prepareTerminalForSessionTransition(in terminalView: LocalProcessTerminalView) {
+            resetPreciseScrollState()
+            // The SwiftTerm view is reused while tmux switches sessions; clear its local
+            // emulator state before tmux redraws so the scrollbar cannot expose old scrollback.
+            terminalView.feed(text: "\u{1B}c")
+        }
+
         private func handleScrollWheel(_ event: NSEvent) -> Bool {
-            guard let terminalView else {
+            guard let terminalView,
+                  let terminalWindow = terminalView.window,
+                  let eventWindow = event.window,
+                  eventWindow === terminalWindow else {
                 return false
             }
 
             let terminal = terminalView.getTerminal()
-            guard terminalView.allowMouseReporting, terminal.mouseMode != .off else {
-                return false
-            }
-
-            guard event.window === terminalView.window else {
-                return false
-            }
-
             let point = terminalView.convert(event.locationInWindow, from: nil)
             guard terminalView.bounds.contains(point) else {
+                resetPreciseScrollState()
                 return false
             }
 
             let scrollSteps = scrollSteps(for: event, in: terminalView, terminal: terminal)
+            guard terminalView.allowMouseReporting, terminal.mouseMode != .off else {
+                if scrollSteps != 0 {
+                    scrollActiveTmuxPaneInCopyMode(steps: scrollSteps)
+                }
+                return scrollSteps != 0 || event.hasPreciseScrollingDeltas || !event.momentumPhase.isEmpty
+            }
+
             guard scrollSteps != 0 else {
                 return event.hasPreciseScrollingDeltas || !event.momentumPhase.isEmpty
             }
@@ -263,13 +339,82 @@ struct TmuxTerminalView: NSViewRepresentable {
             return true
         }
 
+        private func scrollActiveTmuxPaneInCopyMode(steps: Int) {
+            let tty = activeTTY
+            let sessionName = launchedSessionName
+            let lineCount = min(max(abs(steps) * 5, 1), 200)
+            let action = steps > 0 ? "scroll-up" : "scroll-down"
+
+            Task.detached(priority: .userInitiated) {
+                guard let pane = Self.resolveActivePane(tty: tty, sessionName: sessionName) else {
+                    return
+                }
+
+                if steps > 0 {
+                    _ = try? CommandRunner.run(
+                        executable: "/usr/bin/env",
+                        arguments: ["tmux", "copy-mode", "-t", pane]
+                    )
+                }
+
+                let output = try? CommandRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["tmux", "send-keys", "-t", pane, "-X", "-N", String(lineCount), action]
+                )
+
+                guard steps < 0, output?.exitCode == 0 else {
+                    return
+                }
+
+                let scrollPosition = try? CommandRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["tmux", "display-message", "-p", "-t", pane, "#{scroll_position}"]
+                )
+                guard scrollPosition?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "0" else {
+                    return
+                }
+
+                _ = try? CommandRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["tmux", "send-keys", "-t", pane, "-X", "cancel"]
+                )
+            }
+        }
+
+        nonisolated private static func resolveActivePane(tty: String?, sessionName: String?) -> String? {
+            if let tty, !tty.isEmpty {
+                let output = try? CommandRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["tmux", "display-message", "-p", "-c", tty, "#{pane_id}"]
+                )
+                let pane = output?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if output?.exitCode == 0, !pane.isEmpty {
+                    return pane
+                }
+            }
+
+            guard let sessionName, !sessionName.isEmpty else {
+                return nil
+            }
+
+            let output = try? CommandRunner.run(
+                executable: "/usr/bin/env",
+                arguments: ["tmux", "display-message", "-p", "-t", sessionName, "#{pane_id}"]
+            )
+            let pane = output?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return output?.exitCode == 0 && !pane.isEmpty ? pane : nil
+        }
+
         private func scrollSteps(
             for event: NSEvent,
             in terminalView: LocalProcessTerminalView,
             terminal: Terminal
         ) -> Int {
-            if !event.momentumPhase.isEmpty {
+            if event.phase.contains(.began) || !event.momentumPhase.isEmpty {
                 resetPreciseScrollState()
+            }
+
+            if !event.momentumPhase.isEmpty {
                 return 0
             }
 

--- a/Web/app.js
+++ b/Web/app.js
@@ -560,11 +560,18 @@ function attachSession(name) {
     state.socket = ws;
 
     ws.addEventListener('open', () => {
+        if (state.socket !== ws || state.selectedName !== name) {
+            try { ws.close(); } catch (_) {}
+            return;
+        }
         sendResize();
         term.focus();
     });
 
     ws.addEventListener('message', (ev) => {
+        if (state.socket !== ws || state.selectedName !== name) {
+            return;
+        }
         if (typeof ev.data === 'string') {
             term.writeln(ev.data);
             return;


### PR DESCRIPTION
## Summary

Fixes stale terminal history appearing after switching between tmux sessions in SwiftMux.

## Root Cause

The native app reuses one SwiftTerm terminal view while `tmux switch-client` changes the attached session. SwiftTerm keeps its own local scrollback buffer, so after switching sessions the native scrollbar could still reveal output from the previously attached session.

The first implementation also exposed a SwiftUI/AppKit update-loop crash because terminal status publication and terminal reset work could run synchronously from the `NSViewRepresentable.updateNSView` pass. Scrolling then triggered SwiftUI runtime warnings about publishing changes during view updates and could crash during layout.

Scroll behavior was also inconsistent across tmux windows because SwiftTerm only forwarded scroll events when the child terminal mode had mouse reporting enabled. Windows without active mouse reporting fell back to SwiftTerm's native scrollback, which could expose stale history. Simply consuming that fallback made trackpad scrolling appear dead, so this now drives tmux copy-mode directly when mouse reporting is off.

## Changes

- Clear SwiftTerm's local emulator state before switching tmux sessions so stale scrollback cannot remain visible.
- Defer terminal-state publication and the tmux switch reset sequence out of `updateNSView`.
- Track pending session switches so repeated SwiftUI updates do not enqueue duplicate switch requests.
- Tighten scroll-wheel event monitor filtering to require a real terminal window match before handling the event.
- Forward scroll normally when mouse reporting is active.
- When mouse reporting is off, resolve the active tmux pane for SwiftMux's client and send tmux copy-mode `scroll-up` / `scroll-down` commands directly.
- Exit copy-mode after scrolling down to the bottom so typing resumes normally.
- Reset precise-scroll accumulation on gesture begin, momentum events, terminal transitions, and when scroll leaves the terminal pane.
- Reset transient title/current-directory/status state while a switch is in progress.
- Ignore stale async switch and TTY handshake completions for no-longer-selected sessions.
- Ignore stale WebSocket `open` and `message` events in the browser terminal after switching sessions.

## Validation

- `just build`
- `just dev-run`
- `node --check Web/app.js`
- `git diff --check`

I relaunched `SwiftMux Dev.app` from this worktree after the copy-mode fallback fix. Automated scroll input was not available because the installed `cliclick` lacks scroll-wheel support and does not have Accessibility permission, so the final trackpad gesture still needs manual confirmation in the running dev app.