### PR TITLE
Harden remote-control server: mandatory auth + Origin allowlist

### DIFF
--- a/Sources/SwiftMux/Views/RemoteControlSheetView.swift
+++ b/Sources/SwiftMux/Views/RemoteControlSheetView.swift
@@ -10,8 +10,6 @@ struct RemoteControlSheetView: View {
     private var bindModeRaw = RemoteServerBindMode.local.rawValue
     @AppStorage("swiftmux.remote.port")
     private var port = 8421
-    @AppStorage("swiftmux.remote.require-token")
-    private var requireToken = false
     @AppStorage("swiftmux.remote.token")
     private var token = ""
 
@@ -23,11 +21,8 @@ struct RemoteControlSheetView: View {
         }
         nonmutating set {
             bindModeRaw = newValue.rawValue
-            if newValue == .network {
-                requireToken = true
-                if token.isEmpty {
-                    token = RemoteServerManager.generateToken()
-                }
+            if token.isEmpty {
+                token = RemoteServerManager.generateToken()
             }
         }
     }
@@ -81,43 +76,36 @@ struct RemoteControlSheetView: View {
                         .disabled(serverManager.isActive)
                 }
 
-                Toggle("Require bearer token", isOn: $requireToken)
-                    .font(.system(size: 12, weight: .semibold, design: .rounded))
-                    .disabled(serverManager.isActive)
-                    .onChange(of: requireToken) { _, enabled in
-                        if enabled, token.isEmpty {
-                            token = RemoteServerManager.generateToken()
-                        }
-                    }
+                HStack(spacing: 10) {
+                    Text("Token")
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundColor(AppTheme.mutedText)
+                        .frame(width: 86, alignment: .leading)
 
-                if requireToken {
-                    HStack(spacing: 10) {
-                        Text("Token")
-                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                            .foregroundColor(AppTheme.mutedText)
-                            .frame(width: 86, alignment: .leading)
-
-                        TextField("Token", text: $token)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
-                            .disabled(serverManager.isActive)
-
-                        Button {
-                            token = RemoteServerManager.generateToken()
-                        } label: {
-                            Image(systemName: "arrow.clockwise")
-                        }
-                        .help("Regenerate token")
+                    TextField("Token", text: $token)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
                         .disabled(serverManager.isActive)
 
-                        Button {
-                            copy(token)
-                        } label: {
-                            Image(systemName: "doc.on.doc")
-                        }
-                        .help("Copy token")
+                    Button {
+                        token = RemoteServerManager.generateToken()
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
                     }
+                    .help("Regenerate token")
+                    .disabled(serverManager.isActive)
+
+                    Button {
+                        copy(token)
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .help("Copy token")
                 }
+
+                Text("A bearer token is always required. Anyone with this token can control your tmux sessions.")
+                    .font(.system(size: 10, weight: .regular, design: .rounded))
+                    .foregroundColor(AppTheme.mutedText)
             }
             .padding(14)
             .background(AppTheme.elevatedBackground)
@@ -222,7 +210,7 @@ struct RemoteControlSheetView: View {
     }
 
     private var isStartDisabled: Bool {
-        port < 1 || port > 65535 || (requireToken && token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        port < 1 || port > 65535 || token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var canScanFromPhone: Bool {
@@ -230,11 +218,10 @@ struct RemoteControlSheetView: View {
     }
 
     private func startServer() {
-        let activeToken = requireToken ? token : nil
         serverManager.start(
             bindMode: bindMode,
             port: port,
-            token: activeToken
+            token: token
         )
     }
 

--- a/Sources/SwiftMuxCore/SecureToken.swift
+++ b/Sources/SwiftMuxCore/SecureToken.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Security
+
+/// Generates URL-safe random bearer tokens for the remote-control server.
+public enum SecureToken {
+    /// Returns a base64url-encoded random token. 24 bytes ≈ 192 bits of entropy.
+    public static func generate(byteCount: Int = 24) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = bytes.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(kSecRandomDefault, byteCount, buffer.baseAddress!)
+        }
+        if status == errSecSuccess {
+            return Data(bytes).base64URLEncodedString()
+        }
+
+        // SecRandomCopyBytes is not expected to fail on macOS; fall back to UUID entropy.
+        return (UUID().uuidString + UUID().uuidString)
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased()
+    }
+}
+
+private extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Sources/SwiftMuxServer/OriginValidationMiddleware.swift
+++ b/Sources/SwiftMuxServer/OriginValidationMiddleware.swift
@@ -1,0 +1,90 @@
+import Foundation
+import HTTPTypes
+import Hummingbird
+import HummingbirdWebSocket
+
+/// Blocks cross-site requests to the control endpoints by validating the `Origin`
+/// header. Browsers always attach an `Origin` to WebSocket handshakes and to
+/// cross-origin `fetch`/XHR, so a request whose `Origin` does not match the
+/// server's own host (or a loopback address) is a cross-site attempt and is
+/// rejected. This stops a malicious web page from driving the victim's terminal
+/// through their browser (cross-site WebSocket hijacking / CSRF), independently
+/// of the bearer token.
+///
+/// Requests with no `Origin` header (native clients, curl, health checks) are
+/// allowed through — the cross-site threat is browser-only, and those carry an
+/// `Origin`.
+struct OriginValidationMiddleware: RouterMiddleware {
+    typealias Context = BasicWebSocketRequestContext
+
+    func handle(
+        _ request: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
+        guard requiresOriginCheck(path: request.uri.path) else {
+            return try await next(request, context)
+        }
+
+        if let origin = request.headers[.origin], !origin.isEmpty {
+            // `:authority` carries the Host value (swift-http-types marks `.host` unavailable).
+            guard originIsAllowed(origin, host: request.head.authority) else {
+                return Response(status: .forbidden)
+            }
+        }
+
+        return try await next(request, context)
+    }
+
+    private func requiresOriginCheck(path: String) -> Bool {
+        path == "/api" || path.hasPrefix("/api/") ||
+            path == "/ws" || path.hasPrefix("/ws/")
+    }
+
+    /// Allows the request when the `Origin` is a loopback address or when its
+    /// host:port matches the request's own `Host` header (same-origin).
+    private func originIsAllowed(_ origin: String, host: String?) -> Bool {
+        guard let originAuthority = authority(fromOrigin: origin) else {
+            return false
+        }
+        if isLoopbackHost(originAuthority.host) {
+            return true
+        }
+        guard let host, !host.isEmpty else {
+            return false
+        }
+        let requestAuthority = splitAuthority(host)
+        return originAuthority.host.caseInsensitiveCompare(requestAuthority.host) == .orderedSame
+            && originAuthority.port == requestAuthority.port
+    }
+
+    /// Parses an origin like `http://127.0.0.1:8421` into host and port.
+    private func authority(fromOrigin origin: String) -> (host: String, port: Int?)? {
+        guard let components = URLComponents(string: origin), let host = components.host else {
+            return nil
+        }
+        return (host, components.port)
+    }
+
+    /// Parses a `Host` header value like `127.0.0.1:8421`, `example.local`, or
+    /// `[::1]:8421` into host and port.
+    private func splitAuthority(_ value: String) -> (host: String, port: Int?) {
+        if value.hasPrefix("["), let close = value.firstIndex(of: "]") {
+            let host = String(value[value.index(after: value.startIndex)..<close])
+            let rest = value[value.index(after: close)...]
+            let port = rest.hasPrefix(":") ? Int(rest.dropFirst()) : nil
+            return (host, port)
+        }
+
+        let parts = value.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        if parts.count == 2 {
+            return (String(parts[0]), Int(parts[1]))
+        }
+        return (value, nil)
+    }
+
+    private func isLoopbackHost(_ host: String) -> Bool {
+        let lower = host.lowercased()
+        return lower == "localhost" || lower == "127.0.0.1" || lower == "::1"
+    }
+}

--- a/Sources/SwiftMuxServer/SwiftMuxServerApp.swift
+++ b/Sources/SwiftMuxServer/SwiftMuxServerApp.swift
@@ -10,9 +10,15 @@ struct SwiftMuxServerApp {
 
         let router = Router(context: BasicWebSocketRequestContext.self)
 
-        if let token = config.bearerToken {
-            router.add(middleware: BearerTokenMiddleware(token: token))
-        }
+        // The control surface drives live tmux sessions, so it must never run
+        // unauthenticated. Use the operator-provided token, or mint a fresh one
+        // for this run so the server is always behind bearer auth.
+        let token = config.bearerToken ?? SecureToken.generate()
+        let tokenWasGenerated = config.bearerToken == nil
+
+        // Reject cross-site Origins on control endpoints before any work (CSWSH/CSRF).
+        router.add(middleware: OriginValidationMiddleware())
+        router.add(middleware: BearerTokenMiddleware(token: token))
 
         SessionAPI.register(on: router)
         TerminalWebSocket.register(on: router)
@@ -35,15 +41,22 @@ struct SwiftMuxServerApp {
         )
 
         let scheme = "http"
-        let authNote = config.bearerToken == nil
-            ? "no auth (set SWIFTMUX_TOKEN to require Authorization: Bearer ...)"
-            : "bearer-token auth required"
-        print("SwiftMuxServer listening on \(scheme)://\(config.host):\(config.port) - \(authNote)")
+        print("SwiftMuxServer listening on \(scheme)://\(config.host):\(config.port) - bearer-token auth required")
+        if tokenWasGenerated {
+            // No SWIFTMUX_TOKEN was provided; surface the generated token so the
+            // operator can connect. Pin SWIFTMUX_TOKEN to keep a stable token.
+            print("No SWIFTMUX_TOKEN set; generated one for this run:")
+            print("  token: \(token)")
+            print("  url:   \(scheme)://127.0.0.1:\(config.port)/?token=\(token)")
+        }
         if FileManager.default.fileExists(atPath: webRoot) {
             print("Web client mounted from \(webRoot)")
         } else {
             print("No Web client at \(webRoot) - REST/WS only")
         }
+        // stdout is block-buffered when piped (e.g. launched by the app); flush so
+        // the generated token and startup banner are visible immediately.
+        fflush(stdout)
 
         try await app.runService()
     }


### PR DESCRIPTION
## Summary

The remote-control server drives live tmux sessions through a PTY-backed WebSocket (keystroke injection), so any auth gap is effectively remote code execution on the host. This closes the two most serious holes from a security audit of the branch:

- **Auth was opt-in and off by default.** With `SWIFTMUX_TOKEN` unset the server ran fully open, and the app defaulted "Require bearer token" off (so the local-mode default, and a toggled-off network bind on `0.0.0.0`, were unauthenticated). The server now mints a random 192-bit token when none is configured — printed at startup — and **always** installs the bearer middleware. The app drops the no-token path entirely, so it can never launch an unauthenticated server.
- **No Origin validation (CSWSH/CSRF).** WebSocket upgrades and `/api` calls weren't checked, so any web page the user visited could open `ws://127.0.0.1:8421/ws/...` or POST `/kill` cross-site and drive the terminal. New `OriginValidationMiddleware` rejects cross-site `Origin`s on `/api` and `/ws` (same-origin and loopback allowed; absent `Origin` allowed for native clients), running before the bearer check.

Adds `SwiftMuxCore.SecureToken` for shared URL-safe token generation.

### Out of scope (intentionally)
- Token is still passed in the WebSocket URL query string (browsers can't set `Authorization` on WS). The Origin allowlist neutralizes the hijacking risk, but a short-lived WS ticket would remove the token-in-logs exposure.
- Keychain token storage and constant-time token comparison were not included.

Note: the `swiftmux.remote.require-token` UserDefaults key is now orphaned (harmless).

## Test Plan

Both products build clean (`just build`). Runtime smoke test against the server on a spare port with no token set:

- [x] `/healthz` with no auth → 200
- [x] `/api/sessions` with no token → **401** (was open before)
- [x] wrong token → 401
- [x] valid token + cross-site `Origin` → **403**
- [x] valid token + same `Origin` → 200
- [x] valid token + no `Origin` (native client) → 200
- [x] query-string token (browser WS path) → 200
- [x] query token + cross-site `Origin` → **403**
- [x] valid token + loopback `Origin` → 200
- [ ] Manual: launch the app's Remote Control sheet, confirm token is required and Open/QR still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)