### PR TITLE
[codex] Restore tmux scrolling

### DIFF
--- a/Sources/SwiftMux/Views/TmuxTerminalView.swift
+++ b/Sources/SwiftMux/Views/TmuxTerminalView.swift
@@ -107,6 +107,11 @@ struct TmuxTerminalView: NSViewRepresentable {
                 do {
                     _ = try CommandRunner.runExpectingSuccess(
                         executable: "/usr/bin/env",
+                        arguments: ["tmux", "set-option", "-t", targetSessionName, "mouse", "on"]
+                    )
+
+                    _ = try CommandRunner.runExpectingSuccess(
+                        executable: "/usr/bin/env",
                         arguments: ["tmux", "switch-client", "-c", activeTTY, "-t", targetSessionName]
                     )
 
@@ -128,8 +133,8 @@ struct TmuxTerminalView: NSViewRepresentable {
             self.activeTTY = nil
             self.launchedSessionName = sessionName
 
-            // Respect the session's existing tmux mouse configuration so native text selection keeps working.
-            let shellCommand = "tty > \(shellQuoted(ttyHandshakeURL.path)); exec tmux attach-session -t \(shellQuoted(sessionName))"
+            // Enable tmux mouse mode before attaching so wheel events can drive copy-mode scrollback.
+            let shellCommand = "tty > \(shellQuoted(ttyHandshakeURL.path)); tmux set-option -t \(shellQuoted(sessionName)) mouse on 2>/dev/null; exec tmux attach-session -t \(shellQuoted(sessionName))"
 
             terminalView.startProcess(
                 executable: "/bin/sh",


### PR DESCRIPTION
## Summary

Restores tmux-backed scrolling in the native SwiftMux terminal by enabling tmux mouse mode before attaching to a session and before switching the active tmux client to another session.

## Root Cause

SwiftMux forwards scroll-wheel events to tmux only when SwiftTerm reports tmux mouse mode as enabled. The current attach path used plain `tmux attach-session`, so fresh attaches could keep `mouse off`; in that state scroll events fall through and terminal scrollback does not move.

## Impact

Fresh SwiftMux terminal attachments should regain scrollback behavior. This intentionally restores the earlier tradeoff where tmux mouse mode is enabled for SwiftMux sessions, which can affect native text selection.

## Validation

- `just test`
