### PR TITLE
[codex] Restore native-friendly tmux scrollback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,5 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: swift-actions/setup-swift@v3
+        with:
+          swift-version: "6.2.4"
+
       - name: Build
         run: swift build

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Sources/SwiftMux/Views/SwiftMuxTerminalView.swift
+++ b/Sources/SwiftMux/Views/SwiftMuxTerminalView.swift
@@ -49,14 +49,20 @@ final class SwiftMuxTerminalView: LocalProcessTerminalView {
         return hadPendingTarget
     }
 
-    func handleScrollWheel(_ event: NSEvent) -> Bool {
+    func handleScrollWheel(
+        _ event: NSEvent,
+        fallbackWhenMouseReportingUnavailable: (Int) -> Void = { _ in }
+    ) -> Bool {
         let terminal = getTerminal()
+        let scrollSteps = scrollSteps(for: event, terminal: terminal)
+
         guard allowMouseReporting, terminal.mouseMode != .off else {
-            resetPreciseScrollState()
-            return false
+            if scrollSteps != 0 {
+                fallbackWhenMouseReportingUnavailable(scrollSteps)
+            }
+            return scrollSteps != 0 || event.hasPreciseScrollingDeltas || !event.momentumPhase.isEmpty
         }
 
-        let scrollSteps = scrollSteps(for: event, terminal: terminal)
         guard scrollSteps != 0 else {
             return event.hasPreciseScrollingDeltas || !event.momentumPhase.isEmpty
         }
@@ -414,8 +420,11 @@ final class SwiftMuxTerminalView: LocalProcessTerminalView {
     }
 
     private func scrollSteps(for event: NSEvent, terminal: Terminal) -> Int {
-        if !event.momentumPhase.isEmpty {
+        if event.phase.contains(.began) || !event.momentumPhase.isEmpty {
             resetPreciseScrollState()
+        }
+
+        if !event.momentumPhase.isEmpty {
             return 0
         }
 

--- a/Sources/SwiftMux/Views/TmuxTerminalView.swift
+++ b/Sources/SwiftMux/Views/TmuxTerminalView.swift
@@ -23,7 +23,7 @@ struct TmuxTerminalView: NSViewRepresentable {
         view.nativeBackgroundColor = NSColor(calibratedRed: 0.07, green: 0.08, blue: 0.10, alpha: 1.0)
         view.nativeForegroundColor = NSColor(calibratedRed: 0.88, green: 0.91, blue: 0.94, alpha: 1.0)
         view.optionAsMetaKey = false
-        view.allowMouseReporting = true
+        view.allowMouseReporting = false
         view.getTerminal().silentLog = true
         context.coordinator.bind(view)
         return view

--- a/Sources/SwiftMux/Views/TmuxTerminalView.swift
+++ b/Sources/SwiftMux/Views/TmuxTerminalView.swift
@@ -267,7 +267,10 @@ struct TmuxTerminalView: NSViewRepresentable {
 
             switch event.type {
             case .scrollWheel:
-                return terminalView.handleScrollWheel(event) ? nil : event
+                let handled = terminalView.handleScrollWheel(event) { [weak self] scrollSteps in
+                    self?.scrollActiveTmuxPaneInCopyMode(steps: scrollSteps)
+                }
+                return handled ? nil : event
             case .leftMouseDown:
                 if terminalView.beginCommandClick(with: event) {
                     suppressMouseUntilUp = true
@@ -277,6 +280,72 @@ struct TmuxTerminalView: NSViewRepresentable {
             default:
                 return event
             }
+        }
+
+        private func scrollActiveTmuxPaneInCopyMode(steps: Int) {
+            let tty = activeTTY
+            let sessionName = launchedSessionName
+            let lineCount = min(max(abs(steps) * 5, 1), 200)
+            let action = steps > 0 ? "scroll-up" : "scroll-down"
+
+            Task.detached(priority: .userInitiated) {
+                guard let pane = Self.resolveActivePane(tty: tty, sessionName: sessionName) else {
+                    return
+                }
+
+                if steps > 0 {
+                    _ = try? CommandRunner.run(
+                        executable: "/usr/bin/env",
+                        arguments: ["tmux", "copy-mode", "-t", pane]
+                    )
+                }
+
+                let output = try? CommandRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["tmux", "send-keys", "-t", pane, "-X", "-N", String(lineCount), action]
+                )
+
+                guard steps < 0, output?.exitCode == 0 else {
+                    return
+                }
+
+                let scrollPosition = try? CommandRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["tmux", "display-message", "-p", "-t", pane, "#{scroll_position}"]
+                )
+                guard scrollPosition?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "0" else {
+                    return
+                }
+
+                _ = try? CommandRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["tmux", "send-keys", "-t", pane, "-X", "cancel"]
+                )
+            }
+        }
+
+        nonisolated private static func resolveActivePane(tty: String?, sessionName: String?) -> String? {
+            if let tty, !tty.isEmpty {
+                let output = try? CommandRunner.run(
+                    executable: "/usr/bin/env",
+                    arguments: ["tmux", "display-message", "-p", "-c", tty, "#{pane_id}"]
+                )
+                let pane = output?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if output?.exitCode == 0, !pane.isEmpty {
+                    return pane
+                }
+            }
+
+            guard let sessionName, !sessionName.isEmpty else {
+                return nil
+            }
+
+            let output = try? CommandRunner.run(
+                executable: "/usr/bin/env",
+                arguments: ["tmux", "display-message", "-p", "-t", sessionName, "#{pane_id}"]
+            )
+            let pane = output?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return output?.exitCode == 0 && !pane.isEmpty ? pane : nil
         }
 
         nonisolated func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}


### PR DESCRIPTION
## Summary

- Restores scrollback when tmux mouse mode is off, without forcing `tmux mouse on`.
- Keeps the current `SwiftMuxTerminalView` terminal UX/refactor and ports the native-selection-friendly fallback from the older `feat/scrollbar` branch.
- Uses tmux copy-mode commands for scrollback only when SwiftTerm cannot forward mouse-wheel events through tmux mouse reporting.

## Root Cause

Current `main` only handles wheel events when SwiftTerm reports tmux mouse mode as enabled. Because SwiftMux intentionally attaches with plain `tmux attach-session`, sessions with tmux mouse mode off preserve native text selection but wheel events fall through and do not scroll.

PR #8 restored scrolling by enabling tmux mouse mode, but that regressed native text selection behavior. This PR restores the earlier approach from PR #5 while adapting it to the current terminal view code.

## Impact

Scrolling works again for SwiftMux tmux sessions while preserving native text selection when tmux mouse mode is off.

## Validation

- `just test`
- `just app`
- Manual test: scrolling restored in the built app

Supersedes the behavior in PR #8.
