### PR TITLE
[codex] Record stashed session metadata and output batching changes

### DIFF
--- a/Sources/SwiftMux/Services/SessionManager.swift
+++ b/Sources/SwiftMux/Services/SessionManager.swift
@@ -1,5 +1,58 @@
 import Foundation
 
+private let sessionRefreshIntervalNanoseconds: UInt64 = 10_000_000_000
+private let repositoryMetadataCache = ExpiringCache<RepositoryMetadata>()
+private let githubRepoSlugCache = ExpiringCache<String?>()
+
+private struct RepositoryMetadata: Sendable {
+    let canonicalRepoRoot: String?
+    let inferredRepoName: String?
+}
+
+private struct CachedValue<Value: Sendable>: Sendable {
+    let value: Value
+    let expiresAt: Date
+}
+
+private final class ExpiringCache<Value: Sendable>: @unchecked Sendable {
+    private let ttl: TimeInterval
+    private let lock = NSLock()
+    private var values: [String: CachedValue<Value>] = [:]
+
+    init(ttl: TimeInterval = 300) {
+        self.ttl = ttl
+    }
+
+    func value(for path: String, load: () -> Value) -> Value {
+        let key = normalizedPath(path)
+        let now = Date()
+
+        lock.lock()
+        if let cached = values[key], cached.expiresAt > now {
+            lock.unlock()
+            return cached.value
+        }
+        lock.unlock()
+
+        let value = load()
+
+        lock.lock()
+        values[key] = CachedValue(
+            value: value,
+            expiresAt: now.addingTimeInterval(ttl)
+        )
+        lock.unlock()
+
+        return value
+    }
+}
+
+private func normalizedPath(_ path: String) -> String {
+    URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        .standardizedFileURL
+        .path
+}
+
 struct SessionCreationRequest {
     let repoPath: String
     let profile: SessionCreationProfile
@@ -190,7 +243,7 @@ final class SessionManager: ObservableObject {
             await self.refresh()
 
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                try? await Task.sleep(nanoseconds: sessionRefreshIntervalNanoseconds)
                 await self.refresh()
             }
         }
@@ -700,20 +753,37 @@ final class SessionManager: ObservableObject {
         var decoded = try decoder.decode([SessionInfo].self, from: data)
         let activityByName = (try? Self.loadTmuxSessionActivity()) ?? [:]
 
-        // Enrich sessions that lack @repo metadata by resolving git remote
         for i in decoded.indices {
             decoded[i].tmuxActivityAt = activityByName[decoded[i].name]
             let dir = decoded[i].workingDirectory
                 .replacingOccurrences(of: "~", with: NSHomeDirectory())
-            decoded[i].canonicalRepoRoot = Self.resolveCanonicalRepoRoot(at: dir)
-            let repoPath = decoded[i].canonicalRepoRoot ?? dir
-            decoded[i].githubRepoSlug = Self.resolveGitHubRepoSlug(at: repoPath)
+            let metadataRepoPath = Self.absoluteMetadataRepoPath(decoded[i].metadata.repo)
 
-            if decoded[i].metadata.repo == nil || decoded[i].metadata.repo?.isEmpty == true {
-                if let repoRoot = decoded[i].canonicalRepoRoot {
-                    decoded[i].metadata.repo = repoRoot
-                } else if let repoName = Self.resolveGitRepoName(at: dir) {
-                    decoded[i].metadata.repo = repoName
+            if let metadataRepoPath {
+                decoded[i].canonicalRepoRoot = metadataRepoPath
+            } else {
+                let metadata = repositoryMetadataCache.value(for: dir) {
+                    let repoRoot = Self.resolveCanonicalRepoRoot(at: dir)
+                    return RepositoryMetadata(
+                        canonicalRepoRoot: repoRoot,
+                        inferredRepoName: repoRoot == nil ? Self.resolveGitRepoName(at: dir) : nil
+                    )
+                }
+                decoded[i].canonicalRepoRoot = metadata.canonicalRepoRoot
+
+                if decoded[i].metadata.repo == nil || decoded[i].metadata.repo?.isEmpty == true {
+                    if let repoRoot = metadata.canonicalRepoRoot {
+                        decoded[i].metadata.repo = repoRoot
+                    } else if let repoName = metadata.inferredRepoName {
+                        decoded[i].metadata.repo = repoName
+                    }
+                }
+            }
+
+            if decoded[i].metadata.pr?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                let repoPath = decoded[i].canonicalRepoRoot ?? dir
+                decoded[i].githubRepoSlug = githubRepoSlugCache.value(for: repoPath) {
+                    Self.resolveGitHubRepoSlug(at: repoPath)
                 }
             }
         }
@@ -917,6 +987,21 @@ final class SessionManager: ObservableObject {
         let topLevel = topLevelResult?.stdout
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return topLevel.isEmpty ? nil : topLevel
+    }
+
+    nonisolated private static func absoluteMetadataRepoPath(_ repo: String?) -> String? {
+        guard let repo else {
+            return nil
+        }
+
+        let expanded = (repo as NSString)
+            .expandingTildeInPath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard expanded.hasPrefix("/") else {
+            return nil
+        }
+
+        return normalizedPath(expanded)
     }
 
     nonisolated private static func resolveGitHubRepoSlug(at path: String) -> String? {

--- a/Sources/SwiftMux/Views/SwiftMuxTerminalView.swift
+++ b/Sources/SwiftMux/Views/SwiftMuxTerminalView.swift
@@ -2,6 +2,9 @@ import AppKit
 import Foundation
 import SwiftTerm
 
+private let terminalOutputFlushInterval: TimeInterval = 0.08
+private let terminalImmediateFlushByteCount = 64 * 1024
+
 final class SwiftMuxTerminalView: LocalProcessTerminalView {
     var currentWorkingDirectory: String?
     var sessionWorkingDirectory: String?
@@ -9,6 +12,9 @@ final class SwiftMuxTerminalView: LocalProcessTerminalView {
 
     private var pendingOpenTarget: TerminalOpenTarget?
     private var pendingMouseDownLocation: CGPoint?
+    private var pendingOutputBytes: [UInt8] = []
+    private var outputFlushScheduled = false
+    private var lastOutputFlushAt = Date.distantPast
     private var preciseScrollAccumulator: CGFloat = 0
     private var lastPreciseScrollDirection = 0
 
@@ -47,6 +53,21 @@ final class SwiftMuxTerminalView: LocalProcessTerminalView {
         pendingOpenTarget = nil
         pendingMouseDownLocation = nil
         return hadPendingTarget
+    }
+
+    override func dataReceived(slice: ArraySlice<UInt8>) {
+        pendingOutputBytes.append(contentsOf: slice)
+
+        if pendingOutputBytes.count >= terminalImmediateFlushByteCount {
+            flushPendingOutput()
+        } else {
+            flushPendingOutputWhenReady()
+        }
+    }
+
+    override func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+        flushPendingOutput()
+        super.processTerminated(source, exitCode: exitCode)
     }
 
     func handleScrollWheel(
@@ -109,6 +130,44 @@ final class SwiftMuxTerminalView: LocalProcessTerminalView {
         let dx = event.locationInWindow.x - pendingMouseDownLocation.x
         let dy = event.locationInWindow.y - pendingMouseDownLocation.y
         return hypot(dx, dy) <= 4
+    }
+
+    private func flushPendingOutputWhenReady() {
+        let delay = terminalOutputFlushInterval - Date().timeIntervalSince(lastOutputFlushAt)
+        guard delay > 0 else {
+            flushPendingOutput()
+            return
+        }
+
+        schedulePendingOutputFlush(after: delay)
+    }
+
+    private func schedulePendingOutputFlush(after delay: TimeInterval) {
+        guard !outputFlushScheduled else {
+            return
+        }
+
+        outputFlushScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + .nanoseconds(Int(delay * 1_000_000_000))) { [weak self] in
+            guard let self else {
+                return
+            }
+
+            self.outputFlushScheduled = false
+            self.flushPendingOutputWhenReady()
+        }
+    }
+
+    private func flushPendingOutput() {
+        outputFlushScheduled = false
+        guard !pendingOutputBytes.isEmpty else {
+            return
+        }
+
+        let bytes = pendingOutputBytes
+        pendingOutputBytes.removeAll(keepingCapacity: true)
+        lastOutputFlushAt = Date()
+        super.dataReceived(slice: bytes[...])
     }
 
     private func openTarget(for event: NSEvent) -> TerminalOpenTarget? {

--- a/Sources/SwiftMuxCore/SessionService.swift
+++ b/Sources/SwiftMuxCore/SessionService.swift
@@ -1,5 +1,57 @@
 import Foundation
 
+private let repositoryMetadataCache = ExpiringCache<RepositoryMetadata>()
+private let githubRepoSlugCache = ExpiringCache<String?>()
+
+private struct RepositoryMetadata: Sendable {
+    let canonicalRepoRoot: String?
+    let inferredRepoName: String?
+}
+
+private struct CachedValue<Value: Sendable>: Sendable {
+    let value: Value
+    let expiresAt: Date
+}
+
+private final class ExpiringCache<Value: Sendable>: @unchecked Sendable {
+    private let ttl: TimeInterval
+    private let lock = NSLock()
+    private var values: [String: CachedValue<Value>] = [:]
+
+    init(ttl: TimeInterval = 300) {
+        self.ttl = ttl
+    }
+
+    func value(for path: String, load: () -> Value) -> Value {
+        let key = normalizedPath(path)
+        let now = Date()
+
+        lock.lock()
+        if let cached = values[key], cached.expiresAt > now {
+            lock.unlock()
+            return cached.value
+        }
+        lock.unlock()
+
+        let value = load()
+
+        lock.lock()
+        values[key] = CachedValue(
+            value: value,
+            expiresAt: now.addingTimeInterval(ttl)
+        )
+        lock.unlock()
+
+        return value
+    }
+}
+
+private func normalizedPath(_ path: String) -> String {
+    URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        .standardizedFileURL
+        .path
+}
+
 /// Stateless facade over the `tp` and `tmux` CLIs for server-side session access.
 public enum SessionService {
     public static func loadSessions() throws -> [SessionInfo] {
@@ -17,15 +69,33 @@ public enum SessionService {
             decoded[i].tmuxActivityAt = activityByName[decoded[i].name]
             let dir = decoded[i].workingDirectory
                 .replacingOccurrences(of: "~", with: NSHomeDirectory())
-            decoded[i].canonicalRepoRoot = resolveCanonicalRepoRoot(at: dir)
-            let repoPath = decoded[i].canonicalRepoRoot ?? dir
-            decoded[i].githubRepoSlug = resolveGitHubRepoSlug(at: repoPath)
+            let metadataRepoPath = absoluteMetadataRepoPath(decoded[i].metadata.repo)
 
-            if decoded[i].metadata.repo == nil || decoded[i].metadata.repo?.isEmpty == true {
-                if let repoRoot = decoded[i].canonicalRepoRoot {
-                    decoded[i].metadata.repo = repoRoot
-                } else if let repoName = resolveGitRepoName(at: dir) {
-                    decoded[i].metadata.repo = repoName
+            if let metadataRepoPath {
+                decoded[i].canonicalRepoRoot = metadataRepoPath
+            } else {
+                let metadata = repositoryMetadataCache.value(for: dir) {
+                    let repoRoot = resolveCanonicalRepoRoot(at: dir)
+                    return RepositoryMetadata(
+                        canonicalRepoRoot: repoRoot,
+                        inferredRepoName: repoRoot == nil ? resolveGitRepoName(at: dir) : nil
+                    )
+                }
+                decoded[i].canonicalRepoRoot = metadata.canonicalRepoRoot
+
+                if decoded[i].metadata.repo == nil || decoded[i].metadata.repo?.isEmpty == true {
+                    if let repoRoot = metadata.canonicalRepoRoot {
+                        decoded[i].metadata.repo = repoRoot
+                    } else if let repoName = metadata.inferredRepoName {
+                        decoded[i].metadata.repo = repoName
+                    }
+                }
+            }
+
+            if decoded[i].metadata.pr?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                let repoPath = decoded[i].canonicalRepoRoot ?? dir
+                decoded[i].githubRepoSlug = githubRepoSlugCache.value(for: repoPath) {
+                    resolveGitHubRepoSlug(at: repoPath)
                 }
             }
         }
@@ -130,6 +200,21 @@ public enum SessionService {
         let topLevel = topLevelResult?.stdout
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return topLevel.isEmpty ? nil : topLevel
+    }
+
+    private static func absoluteMetadataRepoPath(_ repo: String?) -> String? {
+        guard let repo else {
+            return nil
+        }
+
+        let expanded = (repo as NSString)
+            .expandingTildeInPath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard expanded.hasPrefix("/") else {
+            return nil
+        }
+
+        return normalizedPath(expanded)
     }
 
     private static func resolveGitHubRepoSlug(at path: String) -> String? {


### PR DESCRIPTION
## Summary

This PR preserves the tracked edits that were stashed while recovering the terminal scrolling/selection behavior.

It appears to contain two related performance/metadata changes:

- Adds short-lived caches around repository metadata and GitHub repository slug lookups in both the Swift app session manager and the server-side `SessionService`.
- Treats absolute `@repo` metadata as an authoritative canonical repo path, instead of resolving the git root again from the working directory.
- Only resolves a GitHub repo slug for sessions that actually have PR metadata, avoiding unnecessary remote parsing for ordinary sessions.
- Slows the app session refresh loop from every 2 seconds to every 10 seconds.
- Batches terminal output flushes in `SwiftMuxTerminalView`, with immediate flush for large output bursts.

## Why this exists

These changes were already present locally before the terminal scrolling fix got merged. They were set aside in a stash so `main` could be restored and rebuilt cleanly. This PR is primarily a record of that stash so the work is not lost.

## Notes / Risks

- The session metadata cache code is duplicated between app and server code, so it may deserve cleanup before merging.
- The 10 second refresh interval is a user-visible behavior change and should be reviewed.
- The terminal output batching was resolved on top of the merged native-scrollback work, preserving the current scroll/selection behavior.

## Validation

- `just test`
