### PR TITLE
[codex] Cache session metadata lookups

### DIFF
--- a/Sources/SwiftMux/Services/SessionManager.swift
+++ b/Sources/SwiftMux/Services/SessionManager.swift
@@ -1,5 +1,57 @@
 import Foundation
 
+private let repositoryMetadataCache = ExpiringCache<RepositoryMetadata>()
+private let githubRepoSlugCache = ExpiringCache<String?>()
+
+private struct RepositoryMetadata: Sendable {
+    let canonicalRepoRoot: String?
+    let inferredRepoName: String?
+}
+
+private struct CachedValue<Value: Sendable>: Sendable {
+    let value: Value
+    let expiresAt: Date
+}
+
+private final class ExpiringCache<Value: Sendable>: @unchecked Sendable {
+    private let ttl: TimeInterval
+    private let lock = NSLock()
+    private var values: [String: CachedValue<Value>] = [:]
+
+    init(ttl: TimeInterval = 300) {
+        self.ttl = ttl
+    }
+
+    func value(for path: String, load: () -> Value) -> Value {
+        let key = normalizedPath(path)
+        let now = Date()
+
+        lock.lock()
+        if let cached = values[key], cached.expiresAt > now {
+            lock.unlock()
+            return cached.value
+        }
+        lock.unlock()
+
+        let value = load()
+
+        lock.lock()
+        values[key] = CachedValue(
+            value: value,
+            expiresAt: now.addingTimeInterval(ttl)
+        )
+        lock.unlock()
+
+        return value
+    }
+}
+
+private func normalizedPath(_ path: String) -> String {
+    URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        .standardizedFileURL
+        .path
+}
+
 struct SessionCreationRequest {
     let repoPath: String
     let profile: SessionCreationProfile
@@ -700,20 +752,37 @@ final class SessionManager: ObservableObject {
         var decoded = try decoder.decode([SessionInfo].self, from: data)
         let activityByName = (try? Self.loadTmuxSessionActivity()) ?? [:]
 
-        // Enrich sessions that lack @repo metadata by resolving git remote
         for i in decoded.indices {
             decoded[i].tmuxActivityAt = activityByName[decoded[i].name]
             let dir = decoded[i].workingDirectory
                 .replacingOccurrences(of: "~", with: NSHomeDirectory())
-            decoded[i].canonicalRepoRoot = Self.resolveCanonicalRepoRoot(at: dir)
-            let repoPath = decoded[i].canonicalRepoRoot ?? dir
-            decoded[i].githubRepoSlug = Self.resolveGitHubRepoSlug(at: repoPath)
+            let metadataRepoPath = Self.absoluteMetadataRepoPath(decoded[i].metadata.repo)
 
-            if decoded[i].metadata.repo == nil || decoded[i].metadata.repo?.isEmpty == true {
-                if let repoRoot = decoded[i].canonicalRepoRoot {
-                    decoded[i].metadata.repo = repoRoot
-                } else if let repoName = Self.resolveGitRepoName(at: dir) {
-                    decoded[i].metadata.repo = repoName
+            if let metadataRepoPath {
+                decoded[i].canonicalRepoRoot = metadataRepoPath
+            } else {
+                let metadata = repositoryMetadataCache.value(for: dir) {
+                    let repoRoot = Self.resolveCanonicalRepoRoot(at: dir)
+                    return RepositoryMetadata(
+                        canonicalRepoRoot: repoRoot,
+                        inferredRepoName: repoRoot == nil ? Self.resolveGitRepoName(at: dir) : nil
+                    )
+                }
+                decoded[i].canonicalRepoRoot = metadata.canonicalRepoRoot
+
+                if decoded[i].metadata.repo == nil || decoded[i].metadata.repo?.isEmpty == true {
+                    if let repoRoot = metadata.canonicalRepoRoot {
+                        decoded[i].metadata.repo = repoRoot
+                    } else if let repoName = metadata.inferredRepoName {
+                        decoded[i].metadata.repo = repoName
+                    }
+                }
+            }
+
+            if decoded[i].metadata.pr?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                let repoPath = decoded[i].canonicalRepoRoot ?? dir
+                decoded[i].githubRepoSlug = githubRepoSlugCache.value(for: repoPath) {
+                    Self.resolveGitHubRepoSlug(at: repoPath)
                 }
             }
         }
@@ -917,6 +986,21 @@ final class SessionManager: ObservableObject {
         let topLevel = topLevelResult?.stdout
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return topLevel.isEmpty ? nil : topLevel
+    }
+
+    nonisolated private static func absoluteMetadataRepoPath(_ repo: String?) -> String? {
+        guard let repo else {
+            return nil
+        }
+
+        let expanded = (repo as NSString)
+            .expandingTildeInPath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard expanded.hasPrefix("/") else {
+            return nil
+        }
+
+        return normalizedPath(expanded)
     }
 
     nonisolated private static func resolveGitHubRepoSlug(at path: String) -> String? {

--- a/Sources/SwiftMuxCore/SessionService.swift
+++ b/Sources/SwiftMuxCore/SessionService.swift
@@ -1,5 +1,57 @@
 import Foundation
 
+private let repositoryMetadataCache = ExpiringCache<RepositoryMetadata>()
+private let githubRepoSlugCache = ExpiringCache<String?>()
+
+private struct RepositoryMetadata: Sendable {
+    let canonicalRepoRoot: String?
+    let inferredRepoName: String?
+}
+
+private struct CachedValue<Value: Sendable>: Sendable {
+    let value: Value
+    let expiresAt: Date
+}
+
+private final class ExpiringCache<Value: Sendable>: @unchecked Sendable {
+    private let ttl: TimeInterval
+    private let lock = NSLock()
+    private var values: [String: CachedValue<Value>] = [:]
+
+    init(ttl: TimeInterval = 300) {
+        self.ttl = ttl
+    }
+
+    func value(for path: String, load: () -> Value) -> Value {
+        let key = normalizedPath(path)
+        let now = Date()
+
+        lock.lock()
+        if let cached = values[key], cached.expiresAt > now {
+            lock.unlock()
+            return cached.value
+        }
+        lock.unlock()
+
+        let value = load()
+
+        lock.lock()
+        values[key] = CachedValue(
+            value: value,
+            expiresAt: now.addingTimeInterval(ttl)
+        )
+        lock.unlock()
+
+        return value
+    }
+}
+
+private func normalizedPath(_ path: String) -> String {
+    URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        .standardizedFileURL
+        .path
+}
+
 /// Stateless facade over the `tp` and `tmux` CLIs for server-side session access.
 public enum SessionService {
     public static func loadSessions() throws -> [SessionInfo] {
@@ -17,15 +69,33 @@ public enum SessionService {
             decoded[i].tmuxActivityAt = activityByName[decoded[i].name]
             let dir = decoded[i].workingDirectory
                 .replacingOccurrences(of: "~", with: NSHomeDirectory())
-            decoded[i].canonicalRepoRoot = resolveCanonicalRepoRoot(at: dir)
-            let repoPath = decoded[i].canonicalRepoRoot ?? dir
-            decoded[i].githubRepoSlug = resolveGitHubRepoSlug(at: repoPath)
+            let metadataRepoPath = absoluteMetadataRepoPath(decoded[i].metadata.repo)
 
-            if decoded[i].metadata.repo == nil || decoded[i].metadata.repo?.isEmpty == true {
-                if let repoRoot = decoded[i].canonicalRepoRoot {
-                    decoded[i].metadata.repo = repoRoot
-                } else if let repoName = resolveGitRepoName(at: dir) {
-                    decoded[i].metadata.repo = repoName
+            if let metadataRepoPath {
+                decoded[i].canonicalRepoRoot = metadataRepoPath
+            } else {
+                let metadata = repositoryMetadataCache.value(for: dir) {
+                    let repoRoot = resolveCanonicalRepoRoot(at: dir)
+                    return RepositoryMetadata(
+                        canonicalRepoRoot: repoRoot,
+                        inferredRepoName: repoRoot == nil ? resolveGitRepoName(at: dir) : nil
+                    )
+                }
+                decoded[i].canonicalRepoRoot = metadata.canonicalRepoRoot
+
+                if decoded[i].metadata.repo == nil || decoded[i].metadata.repo?.isEmpty == true {
+                    if let repoRoot = metadata.canonicalRepoRoot {
+                        decoded[i].metadata.repo = repoRoot
+                    } else if let repoName = metadata.inferredRepoName {
+                        decoded[i].metadata.repo = repoName
+                    }
+                }
+            }
+
+            if decoded[i].metadata.pr?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                let repoPath = decoded[i].canonicalRepoRoot ?? dir
+                decoded[i].githubRepoSlug = githubRepoSlugCache.value(for: repoPath) {
+                    resolveGitHubRepoSlug(at: repoPath)
                 }
             }
         }
@@ -130,6 +200,21 @@ public enum SessionService {
         let topLevel = topLevelResult?.stdout
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return topLevel.isEmpty ? nil : topLevel
+    }
+
+    private static func absoluteMetadataRepoPath(_ repo: String?) -> String? {
+        guard let repo else {
+            return nil
+        }
+
+        let expanded = (repo as NSString)
+            .expandingTildeInPath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard expanded.hasPrefix("/") else {
+            return nil
+        }
+
+        return normalizedPath(expanded)
     }
 
     private static func resolveGitHubRepoSlug(at path: String) -> String? {


### PR DESCRIPTION
## Summary
- cache repo-root and inferred repo-name lookups while loading session metadata
- preserve absolute `@repo` paths from session metadata as canonical repo roots
- only resolve and cache GitHub repo slugs when PR metadata is present

## Why
This splits the low-risk metadata portion out of PR #10 so it can be reviewed independently. It reduces repeated git/remote metadata work during session loading without changing terminal behavior or the session refresh cadence.

## Not included
- the 10-second session refresh interval change from PR #10
- terminal output batching from PR #10

## Validation
- `just test`
