### PR TITLE
[codex] Slow session refresh interval

### DIFF
--- a/Sources/SwiftMux/Services/SessionManager.swift
+++ b/Sources/SwiftMux/Services/SessionManager.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private let sessionRefreshIntervalNanoseconds: UInt64 = 10_000_000_000
+
 struct SessionCreationRequest {
     let repoPath: String
     let profile: SessionCreationProfile
@@ -190,7 +192,7 @@ final class SessionManager: ObservableObject {
             await self.refresh()
 
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                try? await Task.sleep(nanoseconds: sessionRefreshIntervalNanoseconds)
                 await self.refresh()
             }
         }


### PR DESCRIPTION
## Summary
- move the app session refresh cadence from 2 seconds to a named 10-second interval

## Why
This splits the refresh-cadence portion out of PR #10 so it can be reviewed independently from metadata caching and terminal output batching.

## Not included
- metadata lookup caching from PR #10
- terminal output batching from PR #10

## Validation
- `just test`
