### PR TITLE
[codex] Add external terminal launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .swiftpm/
 SwiftMux.app/
 SwiftMux Dev.app/
+SwiftMux Test.app/
 *.xcodeproj
 xcuserdata/
 DerivedData/

--- a/Justfile
+++ b/Justfile
@@ -106,7 +106,97 @@ app: build
 run: app
     open SwiftMux.app
 
+# Build side-by-side test .app bundle
+app-test: build
+    #!/bin/bash
+    set -euo pipefail
+    app_bundle="SwiftMux Test.app"
+    bundle_name="SwiftMux Test"
+    bundle_identifier="dev.mungall.SwiftMux.Test"
+    rm -rf "$app_bundle"
+    mkdir -p "$app_bundle/Contents/MacOS"
+    mkdir -p "$app_bundle/Contents/Resources"
+    cp .build/debug/SwiftMux "$app_bundle/Contents/MacOS/"
+    cp .build/debug/SwiftMuxServer "$app_bundle/Contents/MacOS/"
+    cp Sources/SwiftMux/Resources/SwiftMux.icns "$app_bundle/Contents/Resources/"
+    cp -R Web "$app_bundle/Contents/Resources/"
+    actool_log="$(mktemp /tmp/swiftmux-actool.XXXXXX.log)"
+    if ! DEVELOPER_DIR="${SWIFTMUX_XCODE_DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}" \
+        xcrun actool Sources/SwiftMux/Resources/Assets.xcassets \
+        --compile "$app_bundle/Contents/Resources" \
+        --platform macosx \
+        --target-device mac \
+        --minimum-deployment-target 14.0 \
+        --app-icon AppIcon \
+        --output-partial-info-plist /tmp/swiftmux-assets-partial.plist \
+        >/dev/null 2>"$actool_log"; then
+        cat "$actool_log" >&2
+        rm -f "$actool_log"
+        exit 1
+    fi
+    rm -f "$actool_log"
+    xml_escape() {
+        printf '%s' "$1" | sed \
+            -e 's/&/\&amp;/g' \
+            -e 's/</\&lt;/g' \
+            -e 's/>/\&gt;/g' \
+            -e 's/"/\&quot;/g' \
+            -e "s/'/\&apos;/g"
+    }
+    git_commit="$(git rev-parse --short=12 HEAD 2>/dev/null || true)"
+    git_commit="${git_commit:-unknown}"
+    git_branch="$(git branch --show-current 2>/dev/null || true)"
+    git_dirty="false"
+    if [ -n "$(git status --porcelain 2>/dev/null || true)" ]; then
+        git_dirty="true"
+    fi
+    app_version="$(xml_escape "${SWIFTMUX_VERSION:-dev}")"
+    git_commit="$(xml_escape "$git_commit")"
+    git_branch="$(xml_escape "$git_branch")"
+    git_dirty="$(xml_escape "$git_dirty")"
+    bundle_name="$(xml_escape "$bundle_name")"
+    bundle_identifier="$(xml_escape "$bundle_identifier")"
+    cat > "$app_bundle/Contents/Info.plist" << PLIST
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>CFBundleExecutable</key>
+        <string>SwiftMux</string>
+        <key>CFBundleIdentifier</key>
+        <string>$bundle_identifier</string>
+        <key>CFBundleIconName</key>
+        <string>AppIcon</string>
+        <key>CFBundleName</key>
+        <string>$bundle_name</string>
+        <key>CFBundleDisplayName</key>
+        <string>$bundle_name</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>$app_version</string>
+        <key>CFBundleVersion</key>
+        <string>1</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>14.0</string>
+        <key>NSHighResolutionCapable</key>
+        <true/>
+        <key>SwiftMuxGitBranch</key>
+        <string>$git_branch</string>
+        <key>SwiftMuxGitCommit</key>
+        <string>$git_commit</string>
+        <key>SwiftMuxGitDirty</key>
+        <string>$git_dirty</string>
+    </dict>
+    </plist>
+    PLIST
+    echo "$app_bundle built"
+
+# Build and open side-by-side test app
+run-test: app-test
+    open -n "SwiftMux Test.app"
+
 # Clean build artifacts
 clean:
     swift package clean
-    rm -rf SwiftMux.app
+    rm -rf SwiftMux.app "SwiftMux Test.app"

--- a/Sources/SwiftMux/Services/ExternalTerminalLauncher.swift
+++ b/Sources/SwiftMux/Services/ExternalTerminalLauncher.swift
@@ -1,0 +1,257 @@
+import AppKit
+import Foundation
+
+enum ExternalTerminalLauncherError: LocalizedError {
+    case noSupportedTerminal
+    case launchFailed(appName: String, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noSupportedTerminal:
+            return "Install Ghostty, iTerm2, or use Terminal.app to open an external tmux client."
+        case .launchFailed(let appName, let message):
+            return "\(appName) launch failed: \(message)"
+        }
+    }
+}
+
+enum ExternalTerminalLauncher {
+    @MainActor
+    static func open(sessionName: String, workingDirectory: String) async throws {
+        guard let app = TerminalApp.preferredInstalledApp() else {
+            throw ExternalTerminalLauncherError.noSupportedTerminal
+        }
+
+        let title = terminalTitle(for: sessionName)
+        let command = attachCommand(
+            sessionName: sessionName,
+            title: title,
+            workingDirectory: workingDirectory
+        )
+        let script = app.script
+        let appName = app.displayName
+
+        try await Task.detached(priority: .userInitiated) {
+            let output = try CommandRunner.run(
+                executable: "/usr/bin/env",
+                arguments: [
+                    "osascript",
+                    "-e",
+                    script,
+                    "--",
+                    title,
+                    sessionName,
+                    command,
+                    workingDirectory
+                ]
+            )
+
+            guard output.exitCode == 0 else {
+                let stderr = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                let stdout = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                let message = stderr.isEmpty ? (stdout.isEmpty ? "osascript exited with status \(output.exitCode)." : stdout) : stderr
+                throw ExternalTerminalLauncherError.launchFailed(appName: appName, message: message)
+            }
+        }.value
+    }
+
+    private static func terminalTitle(for sessionName: String) -> String {
+        "SwiftMux: \(sessionName)"
+    }
+
+    private static func attachCommand(sessionName: String, title: String, workingDirectory: String) -> String {
+        [
+            "cd \(shellQuoted(workingDirectory)) 2>/dev/null || true",
+            "printf '\\033]0;%s\\007' \(shellQuoted(title))",
+            "tmux set-option -t \(shellQuoted(sessionName)) mouse on 2>/dev/null || true",
+            "tmux set-option -t \(shellQuoted(sessionName)) set-titles on 2>/dev/null || true",
+            "tmux set-option -t \(shellQuoted(sessionName)) set-titles-string \(shellQuoted(tmuxFormatLiteral(title))) 2>/dev/null || true",
+            "exec tmux attach-session -t \(shellQuoted(sessionName))"
+        ].joined(separator: "; ")
+    }
+
+    private static func tmuxFormatLiteral(_ value: String) -> String {
+        value.replacingOccurrences(of: "#", with: "##")
+    }
+
+    private static func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+}
+
+private enum TerminalApp: Sendable {
+    case ghostty
+    case iTerm2
+    case terminal
+
+    var displayName: String {
+        switch self {
+        case .ghostty:
+            return "Ghostty"
+        case .iTerm2:
+            return "iTerm2"
+        case .terminal:
+            return "Terminal"
+        }
+    }
+
+    var bundleIdentifier: String {
+        switch self {
+        case .ghostty:
+            return "com.mitchellh.ghostty"
+        case .iTerm2:
+            return "com.googlecode.iterm2"
+        case .terminal:
+            return "com.apple.Terminal"
+        }
+    }
+
+    var script: String {
+        switch self {
+        case .ghostty:
+            return """
+            on run argv
+                set targetTitle to item 1 of argv
+                set commandText to item 3 of argv
+                set workingDirectory to item 4 of argv
+                set targetWindow to missing value
+
+                tell application id "com.mitchellh.ghostty"
+                    activate
+
+                    repeat with aWindow in windows
+                        repeat with aTab in tabs of aWindow
+                            repeat with aTerminal in terminals of aTab
+                                if (name of aTerminal) contains targetTitle then
+                                    focus aTerminal
+                                    return "focused"
+                                end if
+                                if (targetWindow is missing value) and ((name of aTerminal) contains "SwiftMux: ") then
+                                    set targetWindow to aWindow
+                                end if
+                            end repeat
+                        end repeat
+                    end repeat
+
+                    set cfg to new surface configuration
+                    set initial working directory of cfg to workingDirectory
+                    set initial input of cfg to commandText & linefeed
+                    if targetWindow is missing value then
+                        set newWindow to new window with configuration cfg
+                        activate window newWindow
+                    else
+                        set newTab to new tab in targetWindow with configuration cfg
+                        select tab newTab
+                        activate window targetWindow
+                    end if
+                    return "created"
+                end tell
+            end run
+            """
+        case .iTerm2:
+            return """
+            on run argv
+                set targetTitle to item 1 of argv
+                set targetSession to item 2 of argv
+                set commandText to item 3 of argv
+                set targetWindow to missing value
+
+                tell application id "com.googlecode.iterm2"
+                    activate
+
+                    repeat with aWindow in windows
+                        repeat with aTab in tabs of aWindow
+                            repeat with aSession in sessions of aTab
+                                set isMatch to false
+                                tell aSession
+                                    try
+                                        if (variable "user.swiftmux_session") is targetSession then
+                                            set isMatch to true
+                                        end if
+                                    end try
+                                    if (isMatch is false) and ((name) contains targetTitle) then
+                                        set isMatch to true
+                                    end if
+                                    if targetWindow is missing value then
+                                        try
+                                            if (variable "user.swiftmux_session") is not "" then
+                                                set targetWindow to aWindow
+                                            end if
+                                        end try
+                                        if targetWindow is missing value and ((name) contains "SwiftMux: ") then
+                                            set targetWindow to aWindow
+                                        end if
+                                    end if
+                                end tell
+                                if isMatch then
+                                    select aSession
+                                    select aTab
+                                    select aWindow
+                                    return "focused"
+                                end if
+                            end repeat
+                        end repeat
+                    end repeat
+
+                    if targetWindow is missing value then
+                        set newWindow to (create window with default profile command commandText)
+                        set newSession to current session of newWindow
+                        set newTab to current tab of newWindow
+                        set targetWindow to newWindow
+                    else
+                        tell targetWindow
+                            set newTab to (create tab with default profile command commandText)
+                            set newSession to current session of newTab
+                        end tell
+                    end if
+                    tell newSession
+                        set name to targetTitle
+                        set variable named "user.swiftmux_session" to targetSession
+                    end tell
+                    select newSession
+                    select newTab
+                    select targetWindow
+                    return "created"
+                end tell
+            end run
+            """
+        case .terminal:
+            return """
+            on run argv
+                set targetTitle to item 1 of argv
+                set commandText to item 3 of argv
+
+                tell application id "com.apple.Terminal"
+                    activate
+
+                    repeat with aWindow in windows
+                        repeat with aTab in tabs of aWindow
+                            if (custom title of aTab) is targetTitle then
+                                set selected of aTab to true
+                                set frontmost of aWindow to true
+                                return "focused"
+                            end if
+                        end repeat
+                    end repeat
+
+                    set newTab to do script commandText
+                    set custom title of newTab to targetTitle
+                    set title displays custom title of newTab to true
+                    return "created"
+                end tell
+            end run
+            """
+        }
+    }
+
+    @MainActor
+    static func preferredInstalledApp() -> TerminalApp? {
+        for app in [TerminalApp.ghostty, .iTerm2, .terminal] {
+            if NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleIdentifier) != nil {
+                return app
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/SwiftMux/Views/RootView.swift
+++ b/Sources/SwiftMux/Views/RootView.swift
@@ -1118,6 +1118,8 @@ private struct SessionDetailView: View {
     @State private var prodInFlight = false
     @State private var prodError: String?
     @State private var prodPreview: ToolCommandPreview?
+    @State private var externalTerminalInFlight = false
+    @State private var externalTerminalError: String?
 
     var body: some View {
         ZStack {
@@ -1196,6 +1198,23 @@ private struct SessionDetailView: View {
                             .help("Run `tp prod` for this session.")
 
                             Button {
+                                launchExternalTerminal(for: session)
+                            } label: {
+                                if externalTerminalInFlight {
+                                    HStack(spacing: 8) {
+                                        ProgressView()
+                                            .controlSize(.small)
+                                        Text("Opening…")
+                                    }
+                                } else {
+                                    Label("Terminal", systemImage: "terminal")
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(externalTerminalInFlight)
+                            .help("Open this tmux session in Ghostty, iTerm2, or Terminal.")
+
+                            Button {
                                 presentRenameSheet(for: session)
                             } label: {
                                 Label("Rename", systemImage: "pencil")
@@ -1258,6 +1277,21 @@ private struct SessionDetailView: View {
 
                             Button("Dismiss") {
                                 self.prodError = nil
+                            }
+                        }
+                    }
+
+                    if let externalTerminalError {
+                        HStack {
+                            Text(externalTerminalError)
+                                .font(.system(size: 11, weight: .medium, design: .rounded))
+                                .foregroundColor(.red.opacity(0.9))
+                                .textSelection(.enabled)
+
+                            Spacer(minLength: 12)
+
+                            Button("Dismiss") {
+                                self.externalTerminalError = nil
                             }
                         }
                     }
@@ -1344,12 +1378,14 @@ private struct SessionDetailView: View {
         } message: { session in
             Text("This will terminate the tmux session named \(session.name).")
         }
-        .onChange(of: session?.id) { _ in
+        .onChange(of: session?.id) { _, _ in
             mergeInFlight = false
             mergeError = nil
             prodInFlight = false
             prodError = nil
             prodPreview = nil
+            externalTerminalInFlight = false
+            externalTerminalError = nil
         }
     }
 
@@ -1441,6 +1477,33 @@ private struct SessionDetailView: View {
                 await MainActor.run {
                     prodInFlight = false
                     prodError = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func launchExternalTerminal(for session: SessionInfo) {
+        guard !externalTerminalInFlight else {
+            return
+        }
+
+        externalTerminalError = nil
+        externalTerminalInFlight = true
+
+        Task {
+            do {
+                try await ExternalTerminalLauncher.open(
+                    sessionName: session.name,
+                    workingDirectory: session.resolvedWorkingDirectory
+                )
+
+                await MainActor.run {
+                    externalTerminalInFlight = false
+                }
+            } catch {
+                await MainActor.run {
+                    externalTerminalInFlight = false
+                    externalTerminalError = error.localizedDescription
                 }
             }
         }

--- a/Sources/SwiftMux/Views/TmuxTerminalView.swift
+++ b/Sources/SwiftMux/Views/TmuxTerminalView.swift
@@ -107,6 +107,11 @@ struct TmuxTerminalView: NSViewRepresentable {
                 do {
                     _ = try CommandRunner.runExpectingSuccess(
                         executable: "/usr/bin/env",
+                        arguments: ["tmux", "set-option", "-t", targetSessionName, "mouse", "on"]
+                    )
+
+                    _ = try CommandRunner.runExpectingSuccess(
+                        executable: "/usr/bin/env",
                         arguments: ["tmux", "switch-client", "-c", activeTTY, "-t", targetSessionName]
                     )
 
@@ -128,8 +133,8 @@ struct TmuxTerminalView: NSViewRepresentable {
             self.activeTTY = nil
             self.launchedSessionName = sessionName
 
-            // Respect the session's existing tmux mouse configuration so native text selection keeps working.
-            let shellCommand = "tty > \(shellQuoted(ttyHandshakeURL.path)); exec tmux attach-session -t \(shellQuoted(sessionName))"
+            // Enable tmux mouse mode before attaching so wheel events can drive copy-mode scrollback.
+            let shellCommand = "tty > \(shellQuoted(ttyHandshakeURL.path)); tmux set-option -t \(shellQuoted(sessionName)) mouse on 2>/dev/null; exec tmux attach-session -t \(shellQuoted(sessionName))"
 
             terminalView.startProcess(
                 executable: "/bin/sh",


### PR DESCRIPTION
## Summary

- Add a session header `Terminal` button that launches the selected tmux session in an external terminal.
- Prefer Ghostty, then iTerm2, then Terminal.app; reuse an existing external session tab when possible and group new sessions into the same SwiftMux terminal window.
- Add `just app-test` / `just run-test` for a side-by-side `SwiftMux Test.app` bundle with its own bundle identifier.
- Preserve the branch’s existing tmux scrolling commit, which enables tmux mouse mode during embedded attach/switch.

## Why

The embedded SwiftTerm pane is useful for navigation, but sometimes a full terminal is needed. The launcher opens the same tmux session in a proper terminal without creating duplicate windows for repeated clicks.

Ghostty’s AppleScript `command` field launches a command directly rather than evaluating a shell script, so the Ghostty path uses `initial input` to send the tmux attach command to the launched shell.

## Validation

- `osacompile` for Ghostty launcher script
- `osacompile` for iTerm2 launcher script
- `just app-test`
- `just test`
